### PR TITLE
feat: 세션 기반 로그인/로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/example/jpaPractice/config/SecurityConfig.java
+++ b/src/main/java/com/example/jpaPractice/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())  // CSRF 비활성화 (Postman 테스트 가능하게)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/member/signup", "/api/member/login").permitAll()  // 회원가입 & 로그인은 인증 없이 접근 가능
+                        .requestMatchers("/api/member/signup", "/api/member/login","/api/member/logout",  "/api/member/me").permitAll()  // 회원가입 & 로그인은 인증 없이 접근 가능
                         .anyRequest().authenticated()  // 그 외 요청은 인증 필요
                 );
 

--- a/src/main/java/com/example/jpaPractice/controller/MemberController.java
+++ b/src/main/java/com/example/jpaPractice/controller/MemberController.java
@@ -2,13 +2,12 @@ package com.example.jpaPractice.controller;
 
 import com.example.jpaPractice.dto.LoginRequestDto;
 import com.example.jpaPractice.dto.MemberRequestDto;
+import com.example.jpaPractice.entity.Member;
 import com.example.jpaPractice.service.MemberService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/member")
@@ -23,8 +22,32 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody LoginRequestDto loginRequestDto) {
-        String result = memberService.login(loginRequestDto);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<String> login(@RequestBody LoginRequestDto loginRequestDto, HttpSession session) {
+        Member member = memberService.login(loginRequestDto);
+        session.setAttribute("loginMember",member.getId());
+        return ResponseEntity.ok("로그인 성공!");
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(HttpSession session) {
+        Object loginMember = session.getAttribute("loginMember");
+        System.out.println("현재 로그인된 사용자 ID: " + loginMember);
+
+        if (loginMember == null) {
+            return ResponseEntity.status(401).body("로그인된 사용자만 로그아웃할 수 있습니다.");
+        }
+
+        session.invalidate();
+        return ResponseEntity.ok("로그아웃 성공!");
+    }
+
+
+    @GetMapping("/me")
+    public ResponseEntity<String> getMember(HttpSession session) {
+        Long memberId = (Long) session.getAttribute("loginMember");
+        if (memberId == null) {
+            return ResponseEntity.status(401).body("로그인 안 됨 (세션 없음)");
+        }
+        return ResponseEntity.ok("현재 로그인한 사용자 ID: " + memberId);
     }
 }

--- a/src/main/java/com/example/jpaPractice/service/MemberService.java
+++ b/src/main/java/com/example/jpaPractice/service/MemberService.java
@@ -39,7 +39,7 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public String login(LoginRequestDto requestDto) {
+    public Member login(LoginRequestDto requestDto) {
         Member member = memberRepository.findByEmail(requestDto.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("이메일을 찾을 수 없습니다."));
 
@@ -47,7 +47,7 @@ public class MemberService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        return "로그인 성공!";
+        return member;
 
     }
 


### PR DESCRIPTION
### 세션 기반 로그인/로그아웃 기능 구현
- 로그인 성공 시 세션에 사용자 ID 저장
- 로그아웃 시 세션 무효화
- 인증 상태 확인용 `/me` API 추가