### PR TITLE
feat: Spring Security 기반 수동 인증/인가 구현

### DIFF
--- a/src/main/java/com/example/jpaPractice/config/SecurityConfig.java
+++ b/src/main/java/com/example/jpaPractice/config/SecurityConfig.java
@@ -1,38 +1,53 @@
 package com.example.jpaPractice.config;
 
+import com.example.jpaPractice.service.MemberDetailsService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity //spring boot 3.x에서는 없어도 동작하지만 spring security 활성화 명확하게 표현하려면/ 보통 넣는 게 일반적!
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final MemberDetailsService memberDetailsService;
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-//        http
-//                .csrf(AbstractHttpConfigurer::disable)
-//                .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers("/api/member/**").permitAll()
-//                        .requestMatchers("/api/board/**", "/api/comment/**").authenticated()
-//                        .anyRequest().authenticated()
-//                );
+    public AuthenticationManager authenticationManager(HttpSecurity http, MemberDetailsService memberDetailsService) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder
+                .userDetailsService(memberDetailsService)
+                .passwordEncoder(passwordEncoder());
 
+        return authenticationManagerBuilder.build();
+
+                    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())  // CSRF 비활성화 (Postman 테스트 가능하게)
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/member/signup", "/api/member/login").permitAll()  // 회원가입 & 로그인은 인증 없이 접근 가능
-                        .anyRequest().authenticated()  // 그 외 요청은 인증 필요
-                        .anyRequest().permitAll()  // 모든 요청 인증 없이 허용
-                );
+                        .requestMatchers("/api/member/signup", "/api/member/login").permitAll()
+                        .requestMatchers("/api/board/**", "/api/comment/**").authenticated()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form.disable()) //REST API이므로 비활성화.
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)); //세션 유지
 
 
         return http.build();

--- a/src/main/java/com/example/jpaPractice/controller/MemberController.java
+++ b/src/main/java/com/example/jpaPractice/controller/MemberController.java
@@ -1,13 +1,14 @@
 package com.example.jpaPractice.controller;
 
+import com.example.jpaPractice.entity.MemberDetails;
 import com.example.jpaPractice.dto.LoginRequestDto;
 import com.example.jpaPractice.dto.MemberRequestDto;
 import com.example.jpaPractice.service.MemberService;
 import com.example.jpaPractice.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,31 +27,24 @@ public class MemberController {
     @PostMapping("/login")
 
     public ResponseEntity<String> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletRequest request) {
-        authService.login(loginRequestDto, request);
+        authService.login(loginRequestDto,request);
         return ResponseEntity.ok("로그인 성공!");
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpSession session) {
-        Object loginMember = session.getAttribute("loginMember");
-        System.out.println("현재 로그인된 사용자 ID: " + loginMember);
+    public ResponseEntity<String> logout(HttpServletRequest request) {
+        request.getSession().invalidate(); // 세션 무효화
+        SecurityContextHolder.clearContext();
 
-        if (loginMember == null) {
-            return ResponseEntity.status(401).body("로그인된 사용자만 로그아웃할 수 있습니다.");
-        }
-
-        session.invalidate();
         return ResponseEntity.ok("로그아웃 성공!");
     }
 
 
     @GetMapping("/me")
-    public ResponseEntity<String> getMember(HttpSession session) {
-        Long memberId = (Long) session.getAttribute("loginMember");
-        if (memberId == null) {
-            return ResponseEntity.status(401).body("로그인 안 됨 (세션 없음)");
-        }
-        return ResponseEntity.ok("현재 로그인한 사용자 ID: " + memberId);
+    public ResponseEntity<String> getMember() {
+
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return ResponseEntity.ok("현재 로그인한 사용자 이메일: " + memberDetails.getUsername());
 
     }
 }

--- a/src/main/java/com/example/jpaPractice/entity/MemberDetails.java
+++ b/src/main/java/com/example/jpaPractice/entity/MemberDetails.java
@@ -1,0 +1,44 @@
+package com.example.jpaPractice.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberDetails implements UserDetails {
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+
+}

--- a/src/main/java/com/example/jpaPractice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/jpaPractice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.jpaPractice.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UnauthorizedAccessException.class)
+    public ResponseEntity<String> handleUnauthorizedAccessException(UnauthorizedAccessException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<String> handleCommentNotFoundException(CommentNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(BoardNotFoundException.class)
+    public ResponseEntity<String> handleBoardNotFoundException(BoardNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
+}

--- a/src/main/java/com/example/jpaPractice/service/AuthService.java
+++ b/src/main/java/com/example/jpaPractice/service/AuthService.java
@@ -5,6 +5,7 @@ import com.example.jpaPractice.entity.Member;
 import com.example.jpaPractice.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -17,23 +18,16 @@ import java.util.ArrayList;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
 
-    public void login(LoginRequestDto loginRequestDto, HttpServletRequest request) {
-        Member member = memberRepository.findByEmail(loginRequestDto.getEmail()).orElseThrow(() -> new RuntimeException("해당 이메일을 가진 사용자가 없습니다."));
+    public void login(LoginRequestDto loginRequestDto,HttpServletRequest request) {
+       UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(loginRequestDto.getEmail(), loginRequestDto.getPassword());
 
-        if(!passwordEncoder.matches(loginRequestDto.getPassword(), member.getPassword())){
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
-        }
-
-        Authentication auth = new UsernamePasswordAuthenticationToken(member, null, new ArrayList<>());
-        SecurityContext context = SecurityContextHolder.createEmptyContext();
-        context.setAuthentication(auth);
-        SecurityContextHolder.setContext(context);
-
-        request.getSession().setAttribute("SPRING_SECURITY_CONTEXT", context);
-
+        Authentication authentication = authenticationManager.authenticate(authToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        request.getSession().setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
 
     }
-}
+
+    }
+

--- a/src/main/java/com/example/jpaPractice/service/BoardService.java
+++ b/src/main/java/com/example/jpaPractice/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.example.jpaPractice.service;
 
+import com.example.jpaPractice.entity.MemberDetails;
 import com.example.jpaPractice.exception.BoardNotFoundException;
 import com.example.jpaPractice.dto.BoardDto;
 import com.example.jpaPractice.entity.Board;
@@ -25,12 +26,10 @@ public class BoardService {
 
 
     public BoardDto createBoard(BoardDto boardDto) {
-        Member principal = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member currentUser = memberDetails.getMember();
 
-
-        Member member = memberRepository.findByEmail(principal.getEmail()).orElseThrow(() -> new RuntimeException("Member Not Found"));
-
-        Board board = new Board(boardDto.getTitle(), boardDto.getContent(), member);
+        Board board = new Board(boardDto.getTitle(), boardDto.getContent(), currentUser);
         boardRepository.save(board); //영속 상태로 만들어주기
 
         return new BoardDto(board);
@@ -61,7 +60,9 @@ public class BoardService {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new BoardNotFoundException("게시글을 찾을 수 없습니다."));
 
-        Member currentUser = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member currentUser = memberDetails.getMember(); //실제 Member 꺼내기.
+
         if(!board.getMember().getId().equals(currentUser.getId())) {
             throw new UnauthorizedAccessException("작성자만 수정할 수 있습니다.");
         }
@@ -76,7 +77,9 @@ public class BoardService {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new BoardNotFoundException("게시글을 찾을 수 없습니다."));
 
-        Member currentUser = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member currentUser = memberDetails.getMember();
+
         if(!board.getMember().getId().equals(currentUser.getId())) {
             throw new UnauthorizedAccessException("작성자만 삭제할 수 있습니다.");
         }

--- a/src/main/java/com/example/jpaPractice/service/CommentService.java
+++ b/src/main/java/com/example/jpaPractice/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.example.jpaPractice.service;
 
+import com.example.jpaPractice.entity.MemberDetails;
 import com.example.jpaPractice.dto.CommentDto;
 import com.example.jpaPractice.entity.Board;
 import com.example.jpaPractice.entity.Comment;
@@ -29,9 +30,11 @@ public class CommentService {
     public CommentDto createComment(Long boardId, String content) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardNotFoundException("게시판을 찾을 수 없습니다."));
-        Member member = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        Comment comment = Comment.builder().board(board).member(member).content(content).build();
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member currentUser = memberDetails.getMember();
+
+        Comment comment = Comment.builder().board(board).member(currentUser).content(content).build();
         commentRepository.save(comment);
 
         return new CommentDto(comment);
@@ -51,7 +54,9 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
 
-        Member currentUser =(Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member currentUser = memberDetails.getMember();
+
         if(!comment.getMember().getId().equals(currentUser.getId())) {
             throw new UnauthorizedAccessException("작성자만 수정할 수 있습니다.");
         }
@@ -64,7 +69,9 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
 
-        Member currentUser =(Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member currentUser = memberDetails.getMember();
+
         if(!comment.getMember().getId().equals(currentUser.getId())) {
             throw new UnauthorizedAccessException("작성자만 삭제할 수 있습니다.");
         }

--- a/src/main/java/com/example/jpaPractice/service/MemberDetailsService.java
+++ b/src/main/java/com/example/jpaPractice/service/MemberDetailsService.java
@@ -1,0 +1,23 @@
+package com.example.jpaPractice.service;
+
+import com.example.jpaPractice.entity.MemberDetails;
+import com.example.jpaPractice.entity.Member;
+import com.example.jpaPractice.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+        return new MemberDetails(member);
+    }
+}

--- a/src/main/java/com/example/jpaPractice/service/MemberService.java
+++ b/src/main/java/com/example/jpaPractice/service/MemberService.java
@@ -39,18 +39,6 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public String login(LoginRequestDto requestDto) {
-        Member member = memberRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("이메일을 찾을 수 없습니다."));
-
-        if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
-
-        return "로그인 성공!";
-
-    }
-
 
 
 


### PR DESCRIPTION
Spring Security 환경에서 자동화 없이  AuthenticationManager와 SecurityContextHolder를 사용한  수동 인증/인가 흐름을 구현.

- 로그인 시 Authentication 객체 수동 생성 및 인증 처리
- 인증 정보 SecurityContextHolder에 저장
- 인증된 사용자만 게시글과 댓글 작성/수정/삭제 가능
- 커스텀 예외 및 예외 핸들러 추가
